### PR TITLE
add missing import for javax.ws.rs.PathParam

### DIFF
--- a/ebook/src/main/asciidoc/chapters/building-rest-apis-using-microprofile.adoc
+++ b/ebook/src/main/asciidoc/chapters/building-rest-apis-using-microprofile.adoc
@@ -39,6 +39,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;


### PR DESCRIPTION
add missing import for javax.ws.rs.PathParam, so that when doing cut and paste, compilation works.